### PR TITLE
Support multi panels with multi auth guards

### DIFF
--- a/resources/views/components/banner.blade.php
+++ b/resources/views/components/banner.blade.php
@@ -1,6 +1,6 @@
 @props(['style', 'display', 'fixed', 'position'])
 
-@if(app('impersonate')->isImpersonating())
+@if(app('impersonate')->isImpersonating() && app('impersonate')->getImpersonatorGuardUsingName() === filament()->getCurrentPanel()->getAuthGuard())
 
 @php
 $display = $display ?? Filament\Facades\Filament::getUserName(Filament\Facades\Filament::auth()->user());


### PR DESCRIPTION
Support multi panels with multi auth guards 
this prevent the banner in the Impersonator panel and prevent the issue 

Filament\FilamentManager::getUserName(): Argument #1 ($user) must be of type Illuminate\Database\Eloquent\Model|Illuminate\Contracts\Auth\Authenticatable, null given

Fixes #87

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the impersonation check in the banner component to support multiple authentication guards by comparing the impersonator guard with the current panel's auth guard.

### Why are these changes being made?

To ensure that the impersonation status is accurate when using multiple panels with different authentication guards, thereby enhancing the system's functionality in a multi-panel environment where different authentication contexts are present. This approach addresses the need for nuanced control over user impersonation across varied application segments.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->